### PR TITLE
Remove TerserWebpackPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ cd dist && http-server
 - [`html-webpack-plugin`](https://github.com/jantimon/html-webpack-plugin) - Generate HTML files from template
 - [`mini-css-extract-plugin`](https://github.com/webpack-contrib/mini-css-extract-plugin) - Extract CSS into separate files
 - [`optimize-css-assets-webpack-plugin`](https://github.com/NMFR/optimize-css-assets-webpack-plugin) - Optimize and minimize CSS assets
-- [`terser-webpack-plugin`](https://github.com/webpack-contrib/terser-webpack-plugin) - Optimize and minimize JavaScript
 
 ## Author
 

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -4,7 +4,6 @@ const common = require('./webpack.common.js')
 
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin')
-const TerserPlugin = require('terser-webpack-plugin')
 
 module.exports = merge(common, {
   mode: 'production',
@@ -43,7 +42,7 @@ module.exports = merge(common, {
   },
   optimization: {
     minimize: true,
-    minimizer: [new OptimizeCssAssetsPlugin(), new TerserPlugin()],
+    minimizer: [new OptimizeCssAssetsPlugin()],
     // Once your build outputs multiple chunks, this option will ensure they share the webpack runtime
     // instead of having their own. This also helps with long-term caching, since the chunks will only
     // change when actual code changes, not the webpack runtime.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "postcss-preset-env": "^6.7.0",
     "sass-loader": "^10.0.3",
     "style-loader": "^2.0.0",
-    "terser-webpack-plugin": "^5.0.0",
     "webpack": "^5.1.3",
     "webpack-cli": "^4.0.0",
     "webpack-dev-server": "^3.11.0",


### PR DESCRIPTION
According to the [documentation](https://webpack.js.org/plugins/terser-webpack-plugin/) Webpack v5 comes with the latest terser-webpack-plugin out of the box. So you don't need to install it anymore.

I removed that plugin from `package.json`, `README.md` and `webpack.prod.js`.

Closes #19