### PR TITLE
fixes #26 missing html-loader

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -1,18 +1,18 @@
-const paths = require('./paths')
+const paths = require("./paths");
 
-const { CleanWebpackPlugin } = require('clean-webpack-plugin')
-const CopyWebpackPlugin = require('copy-webpack-plugin')
-const HtmlWebpackPlugin = require('html-webpack-plugin')
+const { CleanWebpackPlugin } = require("clean-webpack-plugin");
+const CopyWebpackPlugin = require("copy-webpack-plugin");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
 
 module.exports = {
   // Where webpack looks to start building the bundle
-  entry: [paths.src + '/index.js'],
+  entry: [paths.src + "/index.js"],
 
   // Where webpack outputs the assets and bundles
   output: {
     path: paths.build,
-    filename: '[name].bundle.js',
-    publicPath: '/',
+    filename: "[name].bundle.js",
+    publicPath: "/",
   },
 
   // Customize the webpack build process
@@ -25,9 +25,9 @@ module.exports = {
       patterns: [
         {
           from: paths.public,
-          to: 'assets',
+          to: "assets",
           globOptions: {
-            ignore: ['*.DS_Store'],
+            ignore: ["*.DS_Store"],
           },
         },
       ],
@@ -36,10 +36,10 @@ module.exports = {
     // Generates an HTML file from a template
     // Generates deprecation warning: https://github.com/jantimon/html-webpack-plugin/issues/1501
     new HtmlWebpackPlugin({
-      title: 'webpack Boilerplate',
-      favicon: paths.src + '/images/favicon.png',
-      template: paths.src + '/template.html', // template file
-      filename: 'index.html', // output file
+      title: "webpack Boilerplate",
+      favicon: paths.src + "/images/favicon.png",
+      template: paths.src + "/template.html", // template file
+      filename: "index.html", // output file
     }),
   ],
 
@@ -47,24 +47,31 @@ module.exports = {
   module: {
     rules: [
       // JavaScript: Use Babel to transpile JavaScript files
-      {test: /\.js$/, exclude: /node_modules/, use: ['babel-loader']},
+      { test: /\.js$/, exclude: /node_modules/, use: ["babel-loader"] },
 
       // Styles: Inject CSS into the head with source maps
       {
         test: /\.(scss|css)$/,
         use: [
-          'style-loader',
-          {loader: 'css-loader', options: {sourceMap: true, importLoaders: 1}},
-          {loader: 'postcss-loader', options: {sourceMap: true}},
-          {loader: 'sass-loader', options: {sourceMap: true}},
+          "style-loader",
+          {
+            loader: "css-loader",
+            options: { sourceMap: true, importLoaders: 1 },
+          },
+          { loader: "postcss-loader", options: { sourceMap: true } },
+          { loader: "sass-loader", options: { sourceMap: true } },
         ],
       },
 
       // Images: Copy image files to build folder
-      {test: /\.(?:ico|gif|png|jpg|jpeg)$/i, type: 'asset/resource'},
+      { test: /\.(?:ico|gif|png|jpg|jpeg)$/i, type: "asset/resource" },
 
       // Fonts and SVGs: Inline files
-      {test: /\.(woff(2)?|eot|ttf|otf|svg|)$/, type: 'asset/inline'},
+      { test: /\.(woff(2)?|eot|ttf|otf|svg|)$/, type: "asset/inline" },
+      {
+        test: /\.html$/,
+        loader: "html-loader",
+      },
     ],
   },
-}
+};

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -1,18 +1,18 @@
-const paths = require("./paths");
+const paths = require('./paths')
 
-const { CleanWebpackPlugin } = require("clean-webpack-plugin");
-const CopyWebpackPlugin = require("copy-webpack-plugin");
-const HtmlWebpackPlugin = require("html-webpack-plugin");
+const { CleanWebpackPlugin } = require('clean-webpack-plugin')
+const CopyWebpackPlugin = require('copy-webpack-plugin')
+const HtmlWebpackPlugin = require('html-webpack-plugin')
 
 module.exports = {
   // Where webpack looks to start building the bundle
-  entry: [paths.src + "/index.js"],
+  entry: [paths.src + '/index.js'],
 
   // Where webpack outputs the assets and bundles
   output: {
     path: paths.build,
-    filename: "[name].bundle.js",
-    publicPath: "/",
+    filename: '[name].bundle.js',
+    publicPath: '/',
   },
 
   // Customize the webpack build process
@@ -25,9 +25,9 @@ module.exports = {
       patterns: [
         {
           from: paths.public,
-          to: "assets",
+          to: 'assets',
           globOptions: {
-            ignore: ["*.DS_Store"],
+            ignore: ['*.DS_Store'],
           },
         },
       ],
@@ -36,10 +36,10 @@ module.exports = {
     // Generates an HTML file from a template
     // Generates deprecation warning: https://github.com/jantimon/html-webpack-plugin/issues/1501
     new HtmlWebpackPlugin({
-      title: "webpack Boilerplate",
-      favicon: paths.src + "/images/favicon.png",
-      template: paths.src + "/template.html", // template file
-      filename: "index.html", // output file
+      title: 'webpack Boilerplate',
+      favicon: paths.src + '/images/favicon.png',
+      template: paths.src + '/template.html', // template file
+      filename: 'index.html', // output file
     }),
   ],
 
@@ -47,105 +47,25 @@ module.exports = {
   module: {
     rules: [
       // JavaScript: Use Babel to transpile JavaScript files
-      { test: /\.js$/, exclude: /node_modules/, use: ["babel-loader"] },
+      {test: /\.js$/, exclude: /node_modules/, use: ['babel-loader']},
 
       // Styles: Inject CSS into the head with source maps
       {
         test: /\.(scss|css)$/,
         use: [
-          "style-loader",
-          {
-            loader: "css-loader",
-            options: { sourceMap: true, importLoaders: 1 },
-          },
-          { loader: "postcss-loader", options: { sourceMap: true } },
-          { loader: "sass-loader", options: { sourceMap: true } },
+          'style-loader',
+          {loader: 'css-loader', options: {sourceMap: true, importLoaders: 1}},
+          {loader: 'postcss-loader', options: {sourceMap: true}},
+          {loader: 'sass-loader', options: {sourceMap: true}},
         ],
       },
 
       // Images: Copy image files to build folder
-      { test: /\.(?:ico|gif|png|jpg|jpeg)$/i, type: "asset/resource" },
+      {test: /\.(?:ico|gif|png|jpg|jpeg)$/i, type: 'asset/resource'},
 
       // Fonts and SVGs: Inline files
-      { test: /\.(woff(2)?|eot|ttf|otf|svg|)$/, type: "asset/inline" },
-      {
-        test: /\.html$/,
-        loader: "html-loader",
-      },
-    ],
-  },
-};
-const paths = require("./paths");
-
-const { CleanWebpackPlugin } = require("clean-webpack-plugin");
-const CopyWebpackPlugin = require("copy-webpack-plugin");
-const HtmlWebpackPlugin = require("html-webpack-plugin");
-
-module.exports = {
-  // Where webpack looks to start building the bundle
-  entry: [paths.src + "/index.js"],
-
-  // Where webpack outputs the assets and bundles
-  output: {
-    path: paths.build,
-    filename: "[name].bundle.js",
-    publicPath: "/",
-  },
-
-  // Customize the webpack build process
-  plugins: [
-    // Removes/cleans build folders and unused assets when rebuilding
-    new CleanWebpackPlugin(),
-
-    // Copies files from target to destination folder
-    new CopyWebpackPlugin({
-      patterns: [
-        {
-          from: paths.public,
-          to: "assets",
-          globOptions: {
-            ignore: ["*.DS_Store"],
-          },
-        },
-      ],
-    }),
-
-    // Generates an HTML file from a template
-    // Generates deprecation warning: https://github.com/jantimon/html-webpack-plugin/issues/1501
-    new HtmlWebpackPlugin({
-      title: "webpack Boilerplate",
-      favicon: paths.src + "/images/favicon.png",
-      template: paths.src + "/template.html", // template file
-      filename: "index.html", // output file
-    }),
-  ],
-
-  // Determine how modules within the project are treated
-  module: {
-    rules: [
-      // JavaScript: Use Babel to transpile JavaScript files
-      { test: /\.js$/, exclude: /node_modules/, use: ["babel-loader"] },
-
-      // Styles: Inject CSS into the head with source maps
-      {
-        test: /\.(scss|css)$/,
-        use: [
-          "style-loader",
-          {
-            loader: "css-loader",
-            options: { sourceMap: true, importLoaders: 1 },
-          },
-          { loader: "postcss-loader", options: { sourceMap: true } },
-          { loader: "sass-loader", options: { sourceMap: true } },
-        ],
-      },
-
-      // Images: Copy image files to build folder
-      { test: /\.(?:ico|gif|png|jpg|jpeg)$/i, type: "asset/resource" },
-
-      // Fonts and SVGs: Inline files
-      { test: /\.(woff(2)?|eot|ttf|otf|svg|)$/, type: "asset/inline" },
+      {test: /\.(woff(2)?|eot|ttf|otf|svg|)$/, type: 'asset/inline'},
       { test: /\.html$/, loader: "html-loader" },
     ],
   },
-};
+}

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -75,3 +75,77 @@ module.exports = {
     ],
   },
 };
+const paths = require("./paths");
+
+const { CleanWebpackPlugin } = require("clean-webpack-plugin");
+const CopyWebpackPlugin = require("copy-webpack-plugin");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+
+module.exports = {
+  // Where webpack looks to start building the bundle
+  entry: [paths.src + "/index.js"],
+
+  // Where webpack outputs the assets and bundles
+  output: {
+    path: paths.build,
+    filename: "[name].bundle.js",
+    publicPath: "/",
+  },
+
+  // Customize the webpack build process
+  plugins: [
+    // Removes/cleans build folders and unused assets when rebuilding
+    new CleanWebpackPlugin(),
+
+    // Copies files from target to destination folder
+    new CopyWebpackPlugin({
+      patterns: [
+        {
+          from: paths.public,
+          to: "assets",
+          globOptions: {
+            ignore: ["*.DS_Store"],
+          },
+        },
+      ],
+    }),
+
+    // Generates an HTML file from a template
+    // Generates deprecation warning: https://github.com/jantimon/html-webpack-plugin/issues/1501
+    new HtmlWebpackPlugin({
+      title: "webpack Boilerplate",
+      favicon: paths.src + "/images/favicon.png",
+      template: paths.src + "/template.html", // template file
+      filename: "index.html", // output file
+    }),
+  ],
+
+  // Determine how modules within the project are treated
+  module: {
+    rules: [
+      // JavaScript: Use Babel to transpile JavaScript files
+      { test: /\.js$/, exclude: /node_modules/, use: ["babel-loader"] },
+
+      // Styles: Inject CSS into the head with source maps
+      {
+        test: /\.(scss|css)$/,
+        use: [
+          "style-loader",
+          {
+            loader: "css-loader",
+            options: { sourceMap: true, importLoaders: 1 },
+          },
+          { loader: "postcss-loader", options: { sourceMap: true } },
+          { loader: "sass-loader", options: { sourceMap: true } },
+        ],
+      },
+
+      // Images: Copy image files to build folder
+      { test: /\.(?:ico|gif|png|jpg|jpeg)$/i, type: "asset/resource" },
+
+      // Fonts and SVGs: Inline files
+      { test: /\.(woff(2)?|eot|ttf|otf|svg|)$/, type: "asset/inline" },
+      { test: /\.html$/, loader: "html-loader" },
+    ],
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -6280,6 +6280,91 @@
       "integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA==",
       "dev": true
     },
+    "html-loader": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-1.3.2.tgz",
+      "integrity": "sha512-DEkUwSd0sijK5PF3kRWspYi56XP7bTNkyg5YWSzBdjaSDmvCufep5c4Vpb3PBf6lUL0YPtLwBfy9fL0t5hBAGA==",
+      "dev": true,
+      "requires": {
+        "html-minifier-terser": "^5.1.1",
+        "htmlparser2": "^4.1.0",
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.1.0.tgz",
+          "integrity": "sha512-ox7bvGXt2n+uLWtCRLybYx60IrOlWL/aCebWJk1T0d4m3y2tzf4U3ij9wBMUb6YJZpz06HCCYuyCDveE2xXmzQ==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.0.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "domelementtype": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz",
+          "integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA==",
+          "dev": true
+        },
+        "domhandler": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+          "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1"
+          }
+        },
+        "domutils": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.2.tgz",
+          "integrity": "sha512-NKbgaM8ZJOecTZsIzW5gSuplsX2IWW2mIK7xVr8hTQF2v1CJWTmLZ1HOCh5sH+IzVPAGE5IucooOkvwBRAdowA==",
+          "dev": true,
+          "requires": {
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.3.0"
+          }
+        },
+        "htmlparser2": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
+          "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.0.0",
+            "domutils": "^2.0.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "schema-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.6",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
+    },
     "html-minifier-terser": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "cross-env": "^7.0.2",
     "css-loader": "^5.0.0",
     "css-minimizer-webpack-plugin": "^1.1.5",
+    "html-loader": "^1.3.2",
     "html-webpack-plugin": "^5.0.0-alpha.7",
     "mini-css-extract-plugin": "^1.0.0",
     "node-sass": "^4.14.1",


### PR DESCRIPTION
If you try to add an image directly to the HTML it won't be processed by webpack and won't be displayed, for instance you can add the following to your template.html file.

Steps:

- Install _html-loader_

- Configure it on wepback common:

```javascript
      {
        test: /\.html$/,
        loader: "html-loader",
      },
```