### PR TITLE
Update css minimizer optimisation plugin for Webpack 5

### DIFF
--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -3,7 +3,7 @@ const { merge } = require('webpack-merge')
 const common = require('./webpack.common.js')
 
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
-const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin')
+const CssMinimizerPlugin = require('css-minimizer-webpack-plugin')
 
 module.exports = merge(common, {
   mode: 'production',
@@ -42,7 +42,7 @@ module.exports = merge(common, {
   },
   optimization: {
     minimize: true,
-    minimizer: [new OptimizeCssAssetsPlugin(), "..."],
+    minimizer: [new CssMinimizerPlugin(), "..."],
     // Once your build outputs multiple chunks, this option will ensure they share the webpack runtime
     // instead of having their own. This also helps with long-term caching, since the chunks will only
     // change when actual code changes, not the webpack runtime.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4520,28 +4520,28 @@
       "dev": true
     },
     "csso": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-4.0.3.tgz",
-      "integrity": "sha512-NL3spysxUkcrOgnpsT4Xdl2aiEiBG6bXswAABQVHcMrfjjBisFOKwLDOmf4wf32aPdcJws1zds2B0Rg+jqMyHQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-4.1.0.tgz",
+      "integrity": "sha512-h+6w/W1WqXaJA4tb1dk7r5tVbOm97MsKxzwnvOR04UQ6GILroryjMWu3pmCCtL2mLaEStQ0fZgeGiy99mo7iyg==",
       "dev": true,
       "requires": {
-        "css-tree": "1.0.0-alpha.39"
+        "css-tree": "^1.0.0"
       },
       "dependencies": {
         "css-tree": {
-          "version": "1.0.0-alpha.39",
-          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.39.tgz",
-          "integrity": "sha512-7UvkEYgBAHRG9Nt980lYxjsTrCyHFN53ky3wVsDkiMdVqylqRt+Zc+jm5qw7/qyOvN2dHSYtX0e4MbCCExSvnA==",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0.tgz",
+          "integrity": "sha512-CdVYz/Yuqw0VdKhXPBIgi8DO3NicJVYZNWeX9XcIuSp9ZoFT5IcleVRW07O5rMjdcx1mb+MEJPknTTEW7DdsYw==",
           "dev": true,
           "requires": {
-            "mdn-data": "2.0.6",
+            "mdn-data": "2.0.12",
             "source-map": "^0.6.1"
           }
         },
         "mdn-data": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.6.tgz",
-          "integrity": "sha512-rQvjv71olwNHgiTbfPZFkJtjNMciWgswYeciZhtvWLO8bmX3TnhyA62I6sTWOyZssWHJJjY6/KiWwqQsWWsqOA==",
+          "version": "2.0.12",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.12.tgz",
+          "integrity": "sha512-ULbAlgzVb8IqZ0Hsxm6hHSlQl3Jckst2YEQS7fODu9ilNWy2LvcoSY7TRFIktABP2mdppBioc66va90T+NUs8Q==",
           "dev": true
         },
         "source-map": {
@@ -7479,16 +7479,6 @@
       "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==",
       "dev": true
     },
-    "last-call-webpack-plugin": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz",
-      "integrity": "sha512-7KI2l2GIZa9p2spzPIVZBYyNKkN+e/SQPpnjlTiPhdbDW3F86tdKKELxKpzJ5sgU19wQWsACULZmpTPYHeWO5w==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.5",
-        "webpack-sources": "^1.1.0"
-      }
-    },
     "lazy-cache": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
@@ -8868,16 +8858,6 @@
       "dev": true,
       "requires": {
         "is-wsl": "^1.1.0"
-      }
-    },
-    "optimize-css-assets-webpack-plugin": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.4.tgz",
-      "integrity": "sha512-wqd6FdI2a5/FdoiCNNkEvLeA//lHHfG24Ln2Xm2qqdIk4aOlsR18jwpyOihqQ8849W3qu2DX8fOYxpvTMj+93A==",
-      "dev": true,
-      "requires": {
-        "cssnano": "^4.1.10",
-        "last-call-webpack-plugin": "^3.0.0"
       }
     },
     "original": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "html-webpack-plugin": "^5.0.0-alpha.7",
     "mini-css-extract-plugin": "^1.0.0",
     "node-sass": "^4.14.1",
-    "optimize-css-assets-webpack-plugin": "^5.0.4",
     "postcss-loader": "^4.0.4",
     "postcss-preset-env": "^6.7.0",
     "sass-loader": "^10.0.3",


### PR DESCRIPTION
The optimize-css-assets-webpack-plugin recommends using css-minimizer-webpack-plugin for Webpack 5. 
See the README at: https://github.com/NMFR/optimize-css-assets-webpack-plugin

This PR swaps them over, updating the Production webpack config and the npm dev dependencies.

It also seems that `css-minimizer-webpack-plugin` was already included in package.json. It just wasn't being used yet.

Note: The force push was for a rebase to clean up multiple commits