### PR TITLE
Update webpack.common.js

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -13,6 +13,7 @@ module.exports = {
     path: paths.build,
     filename: '[name].bundle.js',
     publicPath: '/',
+    assetModuleFilename: 'assets/[hash][ext][query]'
   },
 
   // Customize the webpack build process
@@ -61,7 +62,9 @@ module.exports = {
       },
 
       // Images: Copy image files to build folder
-      {test: /\.(?:ico|gif|png|jpg|jpeg)$/i, type: 'asset/resource'},
+      {test: /\.(?:ico|gif|png|jpg|jpeg)$/i, type: 'asset/resource', generator: {
+        filename: 'assets/[hash][ext][query]'
+      }},
 
       // Fonts and SVGs: Inline files
       {test: /\.(woff(2)?|eot|ttf|otf|svg|)$/, type: 'asset/inline'},


### PR DESCRIPTION
Images are now saved to /dist/assets instead of /dist .