### PR TITLE
Moves scss|css rules into dev config

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -49,17 +49,6 @@ module.exports = {
       // JavaScript: Use Babel to transpile JavaScript files
       {test: /\.js$/, exclude: /node_modules/, use: ['babel-loader']},
 
-      // Styles: Inject CSS into the head with source maps
-      {
-        test: /\.(scss|css)$/,
-        use: [
-          'style-loader',
-          {loader: 'css-loader', options: {sourceMap: true, importLoaders: 1}},
-          {loader: 'postcss-loader', options: {sourceMap: true}},
-          {loader: 'sass-loader', options: {sourceMap: true}},
-        ],
-      },
-
       // Images: Copy image files to build folder
       {test: /\.(?:ico|gif|png|jpg|jpeg)$/i, type: 'asset/resource'},
 

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -21,6 +21,21 @@ module.exports = merge(common, {
     port: 8080,
   },
 
+  module: {
+    rules: [
+      // Styles: Inject CSS into the head with source maps
+      {
+        test: /\.(scss|css)$/,
+        use: [
+          'style-loader',
+          {loader: 'css-loader', options: {sourceMap: true, importLoaders: 1, modules: true }},
+          {loader: 'postcss-loader', options: {sourceMap: true}},
+          {loader: 'sass-loader', options: {sourceMap: true}},
+        ],
+      },
+    ]
+  },
+
   plugins: [
     // Only update what has changed on hot reload
     new webpack.HotModuleReplacementPlugin(),

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -13,14 +13,6 @@ module.exports = merge(common, {
     publicPath: '/',
     filename: 'js/[name].[contenthash].bundle.js',
   },
-  plugins: [
-    // Extracts CSS into separate files
-    // Note: style-loader is for development, MiniCssExtractPlugin is for production
-    new MiniCssExtractPlugin({
-      filename: 'styles/[name].[contenthash].css',
-      chunkFilename: '[id].css',
-    }),
-  ],
   module: {
     rules: [
       {
@@ -32,6 +24,7 @@ module.exports = merge(common, {
             options: {
               importLoaders: 2,
               sourceMap: false,
+              modules: true,
             },
           },
           'postcss-loader',
@@ -40,6 +33,14 @@ module.exports = merge(common, {
       },
     ],
   },
+  plugins: [
+    // Extracts CSS into separate files
+    // Note: style-loader is for development, MiniCssExtractPlugin is for production
+    new MiniCssExtractPlugin({
+      filename: 'styles/[name].[contenthash].css',
+      chunkFilename: '[id].css',
+    }),
+  ],
   optimization: {
     minimize: true,
     minimizer: [new CssMinimizerPlugin(), "..."],


### PR DESCRIPTION
Keeping 'scss|css' rules in common config causes conflict for production builds and does not work with css modules. This merge moves scss|css rules into dev config.