### PR TITLE
removed redundant HMR in dev config

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -38,9 +38,4 @@ module.exports = merge(common, {
       },
     ],
   },
-
-  plugins: [
-    // Only update what has changed on hot reload
-    new webpack.HotModuleReplacementPlugin(),
-  ],
 })


### PR DESCRIPTION
Passing the `devServer\hot: true` option pushes the HMR plugin into the plugin array; setting this value does not require us to explicitly push HMR into plugins. Webpack flagged a warning about it.

![webpack-hmr-duplicate](https://user-images.githubusercontent.com/24639120/140622524-6fdef72b-8dfc-40dc-ba81-cefd6e371c8b.png)
.