### PR TITLE
Remove redundant static: paths.public

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -14,7 +14,6 @@ module.exports = merge(common, {
   // Spin up a server for quick development
   devServer: {
     historyApiFallback: true,
-    static: paths.public,
     open: true,
     compress: true,
     hot: true,


### PR DESCRIPTION
`static: paths.public` does not seem to do anything. `example.png` is already being bundled into `assets/example.png` and is being watched from there. When you modify `public/example.png` it goes into `assets/example.png` and then is being reloaded. The file is not being watched from `public`..