### PR TITLE
Replaced 'node-sass' by 'dart-sass'

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "html-webpack-plugin": "^5.3.2",
     "mini-css-extract-plugin": "^2.4.2",
-    "node-sass": "^6.0.1",
+    "sass": "^1.43.5",
     "postcss-loader": "^6.2.0",
     "postcss-preset-env": "^6.7.0",
     "prettier": "^2.4.1",


### PR DESCRIPTION
'node-sass' doesn't support `@use...` syntax to actually use those sass built-in modules. 'dart-sass' handles it perfectly.