### PR TITLE
CI using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,35 @@
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull
+# request events but only for the master branch.
+#
+# Moreover, a periodic rebuild is scheduled to not miss npm security issues
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron:  '0 0 15 * *'
+
+jobs:
+  ci:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Fail on high and critical vulnerabilities in dependencies
+    #
+    # @warning Must run before npm install to defend against post install
+    #     vulnerabilities
+    - name: Audit dependencies
+      run: npx --yes audit-ci@^6 --high --critical
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Build for production
+      run: npm run build
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 📦 webpack Boilerplate
+# 📦 webpack Boilerplate [![Build Status](https://github.com/taniarascia/webpack-boilerplate/actions/workflows/ci.yaml/badge.svg)](https://github.com/taniarascia/webpack-boilerplate/actions)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
Run `npm audit` on all commits to `master` as well as pull requests. Moreover a peridoic rebuild is scheduled and a build badge was added.

Note: The CI will fail until PR #76 is merged. This is intended since the CI should catch vulnerabilities in the future.